### PR TITLE
Conf: 병렬라우팅 for 피드백모달 세팅 #2-01

### DIFF
--- a/portfolio-project/src/app/@modal/(.)feedback/page.tsx
+++ b/portfolio-project/src/app/@modal/(.)feedback/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function FeedbackModal() {
+  const router = useRouter();
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-rose-500 p-8 rounded-lg max-w-md w-full">
+        <h2 className="text-2xl font-bold mb-4">피드백 모달</h2>
+        <p>모달로 열린 피드백</p>
+        <button onClick={() => router.back()} className="mt-4 cursor-pointer">
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/portfolio-project/src/app/@modal/default.tsx
+++ b/portfolio-project/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/portfolio-project/src/app/feedback/page.tsx
+++ b/portfolio-project/src/app/feedback/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function FeedbackPage() {
+  const router = useRouter();
+  return (
+    <main className="min-h-screen p-8">
+      <h1 className="text-4xl font-bold mb-8">피드백 페이지</h1>
+      <p>직접 URL로 접근했을 때 보이는 전체 페이지</p>
+      <button onClick={() => router.back()} className="mt-4 cursor-pointer">
+        닫기
+      </button>
+    </main>
+  );
+}

--- a/portfolio-project/src/app/layout.tsx
+++ b/portfolio-project/src/app/layout.tsx
@@ -9,10 +9,13 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children, modal }: { children: React.ReactNode; modal: React.ReactNode }) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        {children}
+        {modal}
+      </body>
     </html>
   );
 }

--- a/portfolio-project/src/app/page.tsx
+++ b/portfolio-project/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function Home() {
   return (
     <>
@@ -23,6 +25,11 @@ export default function Home() {
           <span className="font-bold text-green-02">Bold 텍스트</span>
           <span className="font-bold bg-green-02">Bold 텍스트</span>
         </div>
+      </div>
+      <div className="mt-8">
+        <Link href="/feedback" className="bg-rose-500 text-white px-4 py-2 rounded hover:bg-rose-600 inline-block">
+          피드백 모달 열기
+        </Link>
       </div>
     </>
   );


### PR DESCRIPTION
> 날짜: 2025-07-06 (MVP 1단계 진행중)
> 

## ✅ PR내용

- [x] 병렬라우팅 for 피드백모달 세팅 #2-01

## 🤔 상세 내용

### 병렬 라우팅이란

병렬 라우팅(Parallel Routes)은 Next.js 13에서 도입된 혁신적인 라우팅 패턴으로, 하나의 레이아웃에서 여러 개의 페이지를 동시에 렌더링할 수 있게 해주는 기능이란다. 즉, 기존의 전통적인 라우팅에서는 한 번에 하나의 페이지만 보여줄 수 있었지만 병렬 라우팅을 사용하면 여러 개의 독립적인 페이지를 한 화면에 동시에 표시할 수 있다.

```jsx
기존 라우팅: 페이지 A → 페이지 B → 페이지 C (순차적)
병렬 라우팅: 페이지 A + 모달 B + 사이드바 C (동시에 한방에 보여주기)
```

### 병렬라우팅이 왜 필요한거지?

예시 상황으로 느껴보자.

1. 메인페이지에서 프로젝트 리스트 페이지로 이동했다.
2. 프로젝트 리스트 페이지 구경중. 
3. 특정 프로젝트의 상세정보를 눌렀더니 상세 화면이 모달형태로 등장한다.
4. 뒤로가기를 누르면 어디로 갈까??

이때 만족해야하는 사항은 아래와 같다.

1. 이전페이지인 프로젝트리스트 페이지를 보여줘야한다. (메인페이지로 이동하면 안됨!)
2. 프로젝트 리스트 페이지에서 구경하던 위치 (스크롤 위치)로 돌려보내줘야한다. 

여러가지 방식을 고려해보자.

1. url변경없는 단순 컴포넌트로 구현한다면, 뒤로가기 클릭시 메인페이지로 이동하는 문제발생
2. 커스텀 라우팅을 도입하여 뒤로가기 클릭시 프로젝트리스트로 보내도록 한다. ⇒ 스크롤 위치 초기화 문제발생
3. 커스컴 라우팅 + 스크롤위치 상태관리 까지 해줘야 문제해결 가능. 

이러한 방식이 “instagram 및 youtube”에서 사용하는 방법이다. 

But! Next.js에서는 병렬라우팅 개념을 통해 간단하게! 이 문제를 해결할 수 있도록한다. 

물론 복잡한 상태관리도 필요하지 않다. 

병렬라우팅 방식에는 여러 장점들이 존재한다!

- 동시에 여러 UI 컴포넌트를 보여주는게 가능하다.
    - 한 화면에서 프로젝트리스트와 프로젝트 상세화면을 동시에 보여줄 수 있다.
    - 예를들어 페이지전환없이 모달창을 보여줄때도 활용가능하다 ( 뒤로가기 누르면 모달만 닫힌다. )
    - 뒤로가기 눌렀을때 이전페이지를 리렌더링 할 필요도 없다.
- 상태보존
    - 스크롤위치상태 외에도 이전페이지에서의 상태들이 보존된다.
- 에러 관리
    - 각 병렬 라우트는 독립적인 error boundary를 가질 수 있어서 한 부분의 오류가 전체 애플리케이션을 중단시키지 않는다.
- SEO
    - 모달도 라우팅되는 URL이 존재하기 때문에 SEO-friendly한 구조를 만들 수 있다는데, 모달 URL에 대해서도 SSR/SSG/메타태그 처리를 해줘야한다.
    - 모달을 useState 기반 컴포넌트로만 띄우고 URL은 그대로인 방식에서는 크롤러가 모달 상태를 인식할 수 없으니깐


때문에 병렬라우팅을 사용했다. 



### 📷 오늘의 스크린샷

![image](https://github.com/user-attachments/assets/0f7dab44-52ce-4f62-9b1b-9da6d0cfc517)

![image](https://github.com/user-attachments/assets/8b8c525c-b94f-4a16-9ff5-784b261f588e)
